### PR TITLE
Add initial Flutter AR app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,11 @@ Testen der Genauigkeit der Erkennungsfunktion
 Überprüfung der plattformübergreifenden Kompatibilität
 Überwachung des Batterieverbrauchs
 Leistungsbenchmarking
+
+## Setup
+
+1. Install Flutter SDK and ensure `flutter` is on your PATH.
+2. Run `flutter pub get` to fetch dependencies.
+3. Use `flutter run` to start the application on a device or simulator.
+
+This project contains a minimal implementation of an edge-based UI with AR integration. The main features can be found in `lib/main.dart`.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:ar_flutter_plugin/ar_flutter_plugin.dart';
+
+void main() {
+  runApp(const EdgeARApp());
+}
+
+class EdgeARApp extends StatelessWidget {
+  const EdgeARApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Edge AR',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const ARHomePage(),
+    );
+  }
+}
+
+class ARHomePage extends StatefulWidget {
+  const ARHomePage({Key? key}) : super(key: key);
+
+  @override
+  State<ARHomePage> createState() => _ARHomePageState();
+}
+
+class _ARHomePageState extends State<ARHomePage> {
+  late ARSessionManager _arSessionManager;
+  late ARObjectManager _arObjectManager;
+
+  bool _showLeftPanel = false;
+  bool _showRightPanel = false;
+  bool _showTopPanel = false;
+  bool _showBottomPanel = false;
+
+  @override
+  void dispose() {
+    _arSessionManager.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: GestureDetector(
+        onPanStart: _handleEdgePan,
+        child: Stack(
+          children: [
+            ARView(onARViewCreated: _onARViewCreated),
+            _buildEdgePanels(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onARViewCreated(
+    ARSessionManager arSessionManager,
+    ARObjectManager arObjectManager,
+    ARAnchorManager arAnchorManager,
+    ARLocationManager arLocationManager,
+  ) {
+    _arSessionManager = arSessionManager;
+    _arObjectManager = arObjectManager;
+    _arSessionManager.onInitialize();
+  }
+
+  void _handleEdgePan(DragStartDetails details) {
+    const edgeSize = 20.0;
+    final size = MediaQuery.of(context).size;
+    if (details.localPosition.dx < edgeSize) {
+      setState(() => _showLeftPanel = !_showLeftPanel);
+    } else if (details.localPosition.dx > size.width - edgeSize) {
+      setState(() => _showRightPanel = !_showRightPanel);
+    } else if (details.localPosition.dy < edgeSize) {
+      setState(() => _showTopPanel = !_showTopPanel);
+    } else if (details.localPosition.dy > size.height - edgeSize) {
+      setState(() => _showBottomPanel = !_showBottomPanel);
+    }
+  }
+
+  Widget _buildEdgePanels() {
+    return Stack(
+      children: [
+        if (_showLeftPanel)
+          Positioned(
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: 200,
+            child: Container(
+              color: Colors.black54,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: const [Text('Navigation')],
+              ),
+            ),
+          ),
+        if (_showRightPanel)
+          Positioned(
+            right: 0,
+            top: 0,
+            bottom: 0,
+            width: 200,
+            child: Container(
+              color: Colors.black54,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: const [Text('Kontext')],
+              ),
+            ),
+          ),
+        if (_showTopPanel)
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 80,
+            child: Container(
+              color: Colors.black54,
+              alignment: Alignment.center,
+              child: const Text('Titel'),
+            ),
+          ),
+        if (_showBottomPanel)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: 80,
+            child: Container(
+              color: Colors.black54,
+              alignment: Alignment.center,
+              child: const Text('Status'),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,24 @@
+name: edge_ar_app
+description: Minimal Edge-based AR Flutter application
+version: 0.1.0
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  ar_flutter_plugin: ^0.6.3
+  camera: ^0.10.0
+  geolocator: ^9.0.2
+  barcode_scan2: ^4.2.0
+  google_ml_kit: ^0.7.0
+  tesseract_ocr: ^1.0.0
+  surrealdb: ^0.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- set up `pubspec.yaml` with AR and detection dependencies
- implement a minimal AR edge-based UI in `lib/main.dart`
- document setup instructions in `README.md`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1972c4f08329a3ade998ea4fb1f5